### PR TITLE
Implement wasmer_instance_is_function_imported() for the C API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,13 +2142,13 @@ checksum = "c702914acda5feeeffbc29e4d953e5b9ce79d8b98da4dbf18a77086e116c5470"
 [[package]]
 name = "wasmparser"
 version = "0.51.4"
-source = "git+https://github.com/ElrondNetwork/wasmparser.rs#f776d0ae8c349463b25d023ab6c8b1a80a761fd7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "wasmparser"
 version = "0.51.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
+source = "git+https://github.com/ElrondNetwork/wasmparser.rs#f776d0ae8c349463b25d023ab6c8b1a80a761fd7"
 
 [[package]]
 name = "wast"

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -322,6 +322,33 @@ pub extern "C" fn wasmer_instance_context_get(
     context as *const wasmer_instance_context_t
 }
 
+/// Verifies whether the specified function name is imported by the given instance.
+#[allow(clippy::cast_ptr_alignment)]
+#[no_mangle]
+pub unsafe extern "C" fn wasmer_instance_is_function_imported(
+    instance: *mut wasmer_instance_t,
+    name: *const c_char,
+) -> bool {
+    if instance.is_null() {
+        return false;
+    }
+
+    if name.is_null() {
+        return false;
+    }
+
+    let instance = &*(instance as *const Instance);
+
+    let func_name_c = CStr::from_ptr(name);
+    let func_name_r = func_name_c.to_str().unwrap();
+
+    let module = instance.module();
+
+    let functions = module.info().name_table.to_vec();
+
+    functions.contains(&func_name_r)
+}
+
 /// Calls an exported function of a WebAssembly instance by `name`
 /// with the provided parameters. The exported function results are
 /// stored on the provided `results` pointer.

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1083,6 +1083,11 @@ uint64_t wasmer_instance_get_points_used(wasmer_instance_t *instance);
 
 uint64_t wasmer_instance_get_runtime_breakpoint_value(wasmer_instance_t *instance);
 
+/**
+ * Verifies whether the specified function name is imported by the given instance.
+ */
+bool wasmer_instance_is_function_imported(wasmer_instance_t *instance, const char *name);
+
 void wasmer_instance_set_points_limit(wasmer_instance_t *instance, uint64_t limit);
 
 void wasmer_instance_set_points_used(wasmer_instance_t *instance, uint64_t new_gas);

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -884,6 +884,9 @@ uint64_t wasmer_instance_get_points_used(wasmer_instance_t *instance);
 
 uint64_t wasmer_instance_get_runtime_breakpoint_value(wasmer_instance_t *instance);
 
+/// Verifies whether the specified function name is imported by the given instance.
+bool wasmer_instance_is_function_imported(wasmer_instance_t *instance, const char *name);
+
 void wasmer_instance_set_points_limit(wasmer_instance_t *instance, uint64_t limit);
 
 void wasmer_instance_set_points_used(wasmer_instance_t *instance, uint64_t new_gas);

--- a/lib/singlepass-backend/src/lib.rs
+++ b/lib/singlepass-backend/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    dead_code,
     nonstandard_style,
     unused_imports,
     unused_mut,


### PR DESCRIPTION
This PR adds `wasmer_instance_is_function_imported()`, which returns `true` if the specified function has been imported by the given instance.