### PR TITLE
Add tentative workflow for linux-amd64

### DIFF
--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -1,0 +1,26 @@
+name: build-linux-amd64-so
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-so:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Make
+        run: make capi-linux-amd64
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          prerelease: true
+          name: ${{ tag_name }}-linux-amd64
+          files: |
+            target/release/libwasmer_linux_amd64.so

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+  pull-requests:
+    branch: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -4,8 +4,10 @@ on:
   push:
     tags:
       - "v*.*.*"
-  pull-requests:
+  pull_requests:
     branch: [ master ]
+    types: [opened, ready_for_review]
+
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,13 +2136,13 @@ checksum = "c702914acda5feeeffbc29e4d953e5b9ce79d8b98da4dbf18a77086e116c5470"
 [[package]]
 name = "wasmparser"
 version = "0.51.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
+source = "git+https://github.com/ElrondNetwork/wasmparser.rs#f776d0ae8c349463b25d023ab6c8b1a80a761fd7"
 
 [[package]]
 name = "wasmparser"
 version = "0.51.4"
-source = "git+https://github.com/ElrondNetwork/wasmparser.rs#f776d0ae8c349463b25d023ab6c8b1a80a761fd7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "wast"

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,18 @@ llvm: spectests-llvm emtests-llvm wasitests-llvm
 capi:
 	cargo build -p wasmer-runtime-c-api --release
 
+capi-linux-amd64: capi
+	mv target/release/libwasmer_runtime_c_api.so target/release/libwasmer_linux_amd64.so
+	patchelf --set-soname libwasmer_linux_amd64.so target/release/libwasmer_linux_amd64.so
+
+capi-linux-arm64: capi
+	mv target/release/libwasmer_runtime_c_api.so target/release/libwasmer_linux_arm64.so
+	patchelf --set-soname libwasmer_linux_arm64.so target/release/libwasmer_linux_arm64.so
+
+capi-osx-arm64: capi
+	mv target/release/libwasmer_runtime_c_api.dylib target/release/libwasmer_darwin_amd64.dylib
+	install_name_tool -id @executable_path/libwasmer_darwin_amd64.dylib target/release/libwasmer_darwin_amd64.dylib;
+
 capi-singlepass:
 	cargo build --manifest-path lib/runtime-c-api/Cargo.toml --release \
 		--no-default-features --features singlepass-backend,wasi


### PR DESCRIPTION
This PR adds a Github workflow for `linux-amd64`. Variants for `darwin-amd64` and `linux-arm64` will be available afterwards.