### PR TITLE
GitHub actions fixes

### DIFF
--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -5,8 +5,6 @@ on:
     tags:
       - "v*.*.*"
   pull_request:
-    branch: [ master ]
-    types:
 
 
 env:
@@ -25,6 +23,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           prerelease: true
-          name: ${{ tag_name }}-linux-amd64
+          name: ${{ github.ref }}-linux-amd64
           files: |
             target/release/libwasmer_linux_amd64.so

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -20,7 +20,6 @@ jobs:
         run: make capi-linux-amd64
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           prerelease: true
           name: ${{ github.ref }}-linux-amd64

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -11,18 +11,30 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-so:
-    runs-on: ubuntu-18.04
+  build:
+    name: Build dynamic library for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            artifact_name: libwasmer_linux_amd64.so
+          - os: macos-11
+            artifact_name: libwasmer_darwin_amd64.dylib
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Make
         run: make capi-linux-amd64
+      - name: Get the version
+        id: get_version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           prerelease: true
-          name: ${{ github.ref }}-linux-amd64
+          name: ${{ steps.get_version.outputs.VERSION }}-linux-amd64
           files: |
-            target/release/libwasmer_linux_amd64.so
+            target/release/${{ matrix.artifact_name }}

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
-  pull_requests:
+  pull_request:
     branch: [ master ]
     types: [opened, ready_for_review]
 

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -6,7 +6,7 @@ on:
       - "v*.*.*"
   pull_request:
     branch: [ master ]
-    types: [opened, ready_for_review]
+    types:
 
 
 env:

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -20,6 +20,7 @@ jobs:
         run: make capi-linux-amd64
       - name: Release
         uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           prerelease: true
           name: ${{ github.ref }}-linux-amd64

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -2,9 +2,8 @@ name: build-linux-amd64-so
 
 on:
   push:
-    tags:
-      - "v*.*.*"
   pull_request:
+  release:
 
 
 env:

--- a/.github/workflows/libwasmer-build.yml
+++ b/.github/workflows/libwasmer-build.yml
@@ -1,0 +1,26 @@
+name: libwasmer-build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build dynamic library for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            artifact_name: libwasmer_linux_amd64.so
+            make_target: capi-linux-amd64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Make
+        run: make ${{ matrix.make_target }}

--- a/.github/workflows/libwasmer-release.yml
+++ b/.github/workflows/libwasmer-release.yml
@@ -18,8 +18,10 @@ jobs:
         include:
           - os: ubuntu-18.04
             artifact_name: libwasmer_linux_amd64.so
+            make_target: capi-linux-amd64
           - os: macos-11
             artifact_name: libwasmer_darwin_amd64.dylib
+            make_target: capi-osx-amd64
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -33,7 +35,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          prerelease: true
           name: ${{ steps.get_version.outputs.VERSION }}-linux-amd64
           files: |
             target/release/${{ matrix.artifact_name }}

--- a/.github/workflows/libwasmer-release.yml
+++ b/.github/workflows/libwasmer-release.yml
@@ -2,6 +2,8 @@ name: libwasmer-release
 
 on:
   release:
+    types:
+      - created
 
 
 env:

--- a/.github/workflows/libwasmer-release.yml
+++ b/.github/workflows/libwasmer-release.yml
@@ -1,8 +1,6 @@
-name: build-linux-amd64-so
+name: libwasmer-release
 
 on:
-  push:
-  pull_request:
   release:
 
 

--- a/.github/workflows/libwasmer-release.yml
+++ b/.github/workflows/libwasmer-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Make
-        run: make capi-linux-amd64
+        run: make ${{ matrix.make_target }}
       - name: Get the version
         id: get_version
         if: startsWith(github.ref, 'refs/tags/')

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ capi-linux-arm64: capi
 	mv target/release/libwasmer_runtime_c_api.so target/release/libwasmer_linux_arm64.so
 	patchelf --set-soname libwasmer_linux_arm64.so target/release/libwasmer_linux_arm64.so
 
-capi-osx-arm64: capi
+capi-osx-amd64: capi
 	mv target/release/libwasmer_runtime_c_api.dylib target/release/libwasmer_darwin_amd64.dylib
 	install_name_tool -id @executable_path/libwasmer_darwin_amd64.dylib target/release/libwasmer_darwin_amd64.dylib;
 


### PR DESCRIPTION
This PR ensures that the workflows work properly:
* `libwasmer-release` is triggered whenever a release is made (pre-releases work too) and it will add the precompiled dynamic libraries for Linux and MacOS to the release
* `libwasmer-build` is triggered on pull requests and just builds the dynamic library for Linux, without uploading it anywhere (a test build)