### PR TITLE
Add BREAKPOINT_VALUE_MEMORY_LIMIT

### DIFF
--- a/lib/middleware-common/src/opcode_control.rs
+++ b/lib/middleware-common/src/opcode_control.rs
@@ -5,7 +5,10 @@ use wasmer_runtime_core::{
     module::ModuleInfo,
 };
 
-use crate::runtime_breakpoints::{push_runtime_breakpoint, BREAKPOINT_VALUE_EXECUTION_FAILED};
+use crate::runtime_breakpoints::{
+    push_runtime_breakpoint,
+    BREAKPOINT_VALUE_MEMORY_LIMIT,
+};
 
 static FIELD_MEMORY_GROW_COUNT: InternalField = InternalField::allocate();
 
@@ -35,7 +38,7 @@ impl OpcodeControl {
         sink.push(Event::WasmOwned(Operator::If {
             ty: WpTypeOrFuncType::Type(WpType::EmptyBlockType),
         }));
-        push_runtime_breakpoint(sink, BREAKPOINT_VALUE_EXECUTION_FAILED);
+        push_runtime_breakpoint(sink, BREAKPOINT_VALUE_MEMORY_LIMIT);
         sink.push(Event::WasmOwned(Operator::End));
     }
 
@@ -63,7 +66,7 @@ impl OpcodeControl {
         sink.push(Event::WasmOwned(Operator::If {
             ty: WpTypeOrFuncType::Type(WpType::EmptyBlockType),
         }));
-        push_runtime_breakpoint(sink, BREAKPOINT_VALUE_EXECUTION_FAILED);
+        push_runtime_breakpoint(sink, BREAKPOINT_VALUE_MEMORY_LIMIT);
         sink.push(Event::WasmOwned(Operator::End));
     }
 }

--- a/lib/middleware-common/src/runtime_breakpoints.rs
+++ b/lib/middleware-common/src/runtime_breakpoints.rs
@@ -11,10 +11,7 @@ pub static FIELD_RUNTIME_BREAKPOINT_VALUE: InternalField = InternalField::alloca
 pub const BREAKPOINT_VALUE_NO_BREAKPOINT: u64 = 0;
 pub const BREAKPOINT_VALUE_EXECUTION_FAILED: u64 = 1;
 pub const BREAKPOINT_VALUE_OUT_OF_GAS: u64 = 4;
-
-
-#[derive(Copy, Clone, Debug)]
-pub struct RuntimeBreakpointReachedError;
+pub const BREAKPOINT_VALUE_MEMORY_LIMIT: u64 = 5;
 
 
 pub struct RuntimeBreakpointHandler {}


### PR DESCRIPTION
This PR changes the breakpoint value set by `OpcodeControl` when too many `memory.grow` opcodes are run. Previously, the breakpoint value was set to `BREAKPOINT_VALUE_EXECUTION_FAILED`, now it's `BREAKPOINT_VALUE_MEMORY_LIMIT`. This way, the VM can distinguish between a generic failure and a failure caused by over-allocation of WASM memory.