### PR TITLE
Instance reset

### DIFF
--- a/.github/workflows/libwasmer-build.yml
+++ b/.github/workflows/libwasmer-build.yml
@@ -24,3 +24,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Make
         run: make ${{ matrix.make_target }}
+      - name: Save artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: libs
+          path: |
+            target/release/*.so
+            target/release/*.dylib

--- a/.github/workflows/libwasmer-build.yml
+++ b/.github/workflows/libwasmer-build.yml
@@ -31,3 +31,5 @@ jobs:
           path: |
             target/release/*.so
             target/release/*.dylib
+            lib/runtime-c-api/wasmer.h
+            lib/runtime-c-api/wasmer.hh

--- a/.github/workflows/libwasmer-build.yml
+++ b/.github/workflows/libwasmer-build.yml
@@ -19,6 +19,9 @@ jobs:
           - os: ubuntu-18.04
             artifact_name: libwasmer_linux_amd64.so
             make_target: capi-linux-amd64
+          - os: macos-11
+            artifact_name: libwasmer_darwin_amd64.dylib
+            make_target: capi-osx-amd64
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,13 +2252,13 @@ checksum = "c702914acda5feeeffbc29e4d953e5b9ce79d8b98da4dbf18a77086e116c5470"
 [[package]]
 name = "wasmparser"
 version = "0.51.4"
-source = "git+https://github.com/ElrondNetwork/wasmparser.rs#f776d0ae8c349463b25d023ab6c8b1a80a761fd7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "wasmparser"
 version = "0.51.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
+source = "git+https://github.com/ElrondNetwork/wasmparser.rs#f776d0ae8c349463b25d023ab6c8b1a80a761fd7"
 
 [[package]]
 name = "wast"

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ test-capi-singlepass: capi-singlepass
 		--no-default-features --features singlepass-backend,wasi
 
 capi-dev:
-	cargo build -p wasmer-runtime-c-api --profile dev -Z unstable-options
+	cargo build -p wasmer-runtime-c-api --profile dev
 
 test-capi: capi
 	cargo test -p wasmer-runtime-c-api --release

--- a/examples/parallel-guest/src/main.rs
+++ b/examples/parallel-guest/src/main.rs
@@ -1,11 +1,13 @@
 #[macro_use]
 extern crate lazy_static;
 
+#[allow(dead_code)]
 extern "C" {
     fn get_hashed_password(ptr: u32, len: u32) -> u32;
     fn print_char(c: u32);
 }
 
+#[allow(dead_code)]
 fn print_str(s: &str) {
     for c in s.chars() {
         unsafe { print_char(c as u32) };

--- a/lib/middleware-common/src/opcode_control.rs
+++ b/lib/middleware-common/src/opcode_control.rs
@@ -1,14 +1,12 @@
 use wasmer_runtime_core::{
     codegen::{Event, EventSink, FunctionMiddleware, InternalEvent},
-    wasmparser::{Operator, Type as WpType, TypeOrFuncType as WpTypeOrFuncType},
-    vm::InternalField,
     module::ModuleInfo,
+    vm::InternalField,
+    wasmparser::{Operator, Type as WpType, TypeOrFuncType as WpTypeOrFuncType},
+    Instance,
 };
 
-use crate::runtime_breakpoints::{
-    push_runtime_breakpoint,
-    BREAKPOINT_VALUE_MEMORY_LIMIT,
-};
+use crate::runtime_breakpoints::{push_runtime_breakpoint, BREAKPOINT_VALUE_MEMORY_LIMIT};
 
 static FIELD_MEMORY_GROW_COUNT: InternalField = InternalField::allocate();
 
@@ -46,9 +44,7 @@ impl OpcodeControl {
         sink.push(Event::Internal(InternalEvent::GetInternal(
             FIELD_MEMORY_GROW_COUNT.index() as _,
         )));
-        sink.push(Event::WasmOwned(Operator::I64Const{
-            value: 1 as i64,
-        }));
+        sink.push(Event::WasmOwned(Operator::I64Const { value: 1 as i64 }));
         sink.push(Event::WasmOwned(Operator::I64Add));
         sink.push(Event::Internal(InternalEvent::SetInternal(
             FIELD_MEMORY_GROW_COUNT.index() as _,
@@ -117,4 +113,9 @@ impl FunctionMiddleware for OpcodeControl {
         sink.push(op);
         Ok(())
     }
+}
+
+/// Sets the number of points used by an Instance.
+pub fn reset_memory_grow_count(instance: &mut Instance) {
+    instance.set_internal(&FIELD_MEMORY_GROW_COUNT, 0);
 }

--- a/lib/middleware-common/src/opcode_control.rs
+++ b/lib/middleware-common/src/opcode_control.rs
@@ -115,7 +115,7 @@ impl FunctionMiddleware for OpcodeControl {
     }
 }
 
-/// Sets the number of points used by an Instance.
+/// Set internal field `FIELD_MEMORY_GROW_COUNT` to 0.
 pub fn reset_memory_grow_count(instance: &mut Instance) {
     instance.set_internal(&FIELD_MEMORY_GROW_COUNT, 0);
 }

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -264,7 +264,7 @@ pub unsafe extern "C" fn wasmer_instantiate_reset(
     }
 
     let instance = &mut *(instance as *mut Instance);
-    instance.reset();
+    let _result = instance.reset();
     wasmer_result_t::WASMER_OK
 }
 

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -267,12 +267,12 @@ pub unsafe extern "C" fn wasmer_instantiate_reset(
     let instance = &mut *(instance as *mut Instance);
 
     if let Err(error) = instance.reset() {
-                update_last_error(CApiError {
+        update_last_error(CApiError {
             msg: error.to_string(),
         });
         return wasmer_result_t::WASMER_ERROR;
     }
-        
+
     wasmer_result_t::WASMER_OK
 }
 

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -251,6 +251,22 @@ pub unsafe extern "C" fn wasmer_instantiate_with_options(
     wasmer_result_t::WASMER_OK
 }
 
+#[allow(clippy::cast_ptr_alignment)]
+#[no_mangle]
+pub unsafe extern "C" fn wasmer_instantiate_reset(
+    instance: *mut *mut wasmer_instance_t,
+) -> wasmer_result_t {
+    if instance.is_null() {
+        update_last_error(CApiError {
+            msg: "null instance".to_string(),
+        });
+        return wasmer_result_t::WASMER_ERROR;
+    }
+
+    let instance = unsafe { &*(instance as *const Instance) };
+    instance.reset();
+}
+
 pub unsafe fn prepare_middleware_chain_generator(
     options: &CompilationOptions
     ) -> impl Fn() -> MiddlewareChain + '_ {

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -254,7 +254,7 @@ pub unsafe extern "C" fn wasmer_instantiate_with_options(
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_instantiate_reset(
-    instance: *mut *mut wasmer_instance_t,
+    instance: *mut wasmer_instance_t,
 ) -> wasmer_result_t {
     if instance.is_null() {
         update_last_error(CApiError {

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -23,7 +23,7 @@ use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
 #[cfg(not(feature = "cranelift-backend"))]
 use wasmer_middleware_common::metering;
 
-use wasmer_middleware_common::opcode_control;
+use wasmer_middleware_common::opcode_control::{self, reset_memory_grow_count};
 use wasmer_middleware_common::opcode_trace;
 use wasmer_middleware_common::runtime_breakpoints;
 
@@ -273,6 +273,8 @@ pub unsafe extern "C" fn wasmer_instantiate_reset(
         });
         return wasmer_result_t::WASMER_ERROR;
     }
+
+    reset_memory_grow_count(instance);
 
     wasmer_result_t::WASMER_OK
 }

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -251,7 +251,7 @@ pub unsafe extern "C" fn wasmer_instantiate_with_options(
     wasmer_result_t::WASMER_OK
 }
 
-/// todo: add documentation
+/// TODO: add documentation
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_instantiate_reset(

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -251,6 +251,7 @@ pub unsafe extern "C" fn wasmer_instantiate_with_options(
     wasmer_result_t::WASMER_OK
 }
 
+/// todo: add documentation
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_instantiate_reset(
@@ -264,7 +265,14 @@ pub unsafe extern "C" fn wasmer_instantiate_reset(
     }
 
     let instance = &mut *(instance as *mut Instance);
-    let _result = instance.reset();
+
+    if let Err(error) = instance.reset() {
+                update_last_error(CApiError {
+            msg: error.to_string(),
+        });
+        return wasmer_result_t::WASMER_ERROR;
+    }
+        
     wasmer_result_t::WASMER_OK
 }
 

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -27,8 +27,6 @@ use wasmer_middleware_common::opcode_control::{self, reset_memory_grow_count};
 use wasmer_middleware_common::opcode_trace;
 use wasmer_middleware_common::runtime_breakpoints;
 
-use wasmer_runtime_core::backing::{RESET_BACKING_GLOBALS, RESET_BACKING_MEMORIES};
-
 /// Opaque pointer to a `wasmer_runtime::Instance` value in Rust.
 ///
 /// A `wasmer_runtime::Instance` represents a WebAssembly instance. It
@@ -252,10 +250,10 @@ pub unsafe extern "C" fn wasmer_instantiate_with_options(
     wasmer_result_t::WASMER_OK
 }
 
-/// Resets an WebAssembly instance, cleaning memory and globals
+/// Reset an WebAssembly instance, cleaning memories and globals
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_instantiate_reset(
+pub unsafe extern "C" fn wasmer_instance_reset(
     instance: *mut wasmer_instance_t,
 ) -> wasmer_result_t {
     if instance.is_null() {
@@ -723,11 +721,4 @@ pub extern "C" fn wasmer_instance_destroy(instance: *mut wasmer_instance_t) {
     if !instance.is_null() {
         unsafe { Box::from_raw(instance as *mut Instance) };
     }
-}
-
-#[allow(clippy::cast_ptr_alignment)]
-#[no_mangle]
-pub unsafe extern "C" fn wasmer_instance_reset_options(reset_memories: bool, reset_globals: bool) {
-    RESET_BACKING_MEMORIES = reset_memories;
-    RESET_BACKING_GLOBALS = reset_globals;
 }

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -16,18 +16,16 @@ use wasmer_runtime_core::{
     import::{ImportObject, Namespace},
 };
 
+use crate::metering::OPCODE_COSTS;
 use wasmer_runtime_core::backend::Compiler;
 use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
-use crate::metering::OPCODE_COSTS;
 
 #[cfg(not(feature = "cranelift-backend"))]
 use wasmer_middleware_common::metering;
 
-use wasmer_middleware_common::runtime_breakpoints;
-use wasmer_middleware_common::opcode_trace;
 use wasmer_middleware_common::opcode_control;
-
-
+use wasmer_middleware_common::opcode_trace;
+use wasmer_middleware_common::runtime_breakpoints;
 
 /// Opaque pointer to a `wasmer_runtime::Instance` value in Rust.
 ///
@@ -191,7 +189,6 @@ pub unsafe extern "C" fn wasmer_instantiate(
     wasmer_result_t::WASMER_OK
 }
 
-
 #[repr(C)]
 pub struct wasmer_import_object_t;
 
@@ -232,7 +229,9 @@ pub unsafe extern "C" fn wasmer_instantiate_with_options(
     let new_module = match result_compilation {
         Ok(module) => module,
         Err(_) => {
-            update_last_error(CApiError { msg: "compile error".to_string() });
+            update_last_error(CApiError {
+                msg: "compile error".to_string(),
+            });
             return wasmer_result_t::WASMER_ERROR;
         }
     };
@@ -251,7 +250,7 @@ pub unsafe extern "C" fn wasmer_instantiate_with_options(
     wasmer_result_t::WASMER_OK
 }
 
-/// TODO: add documentation
+/// Resets an WebAssembly instance, cleaning memory annd globals
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_instantiate_reset(
@@ -277,8 +276,8 @@ pub unsafe extern "C" fn wasmer_instantiate_reset(
 }
 
 pub unsafe fn prepare_middleware_chain_generator(
-    options: &CompilationOptions
-    ) -> impl Fn() -> MiddlewareChain + '_ {
+    options: &CompilationOptions,
+) -> impl Fn() -> MiddlewareChain + '_ {
     let options = options.clone();
 
     let chain_generator = move || {
@@ -287,15 +286,15 @@ pub unsafe fn prepare_middleware_chain_generator(
         if options.metering {
             #[cfg(feature = "metering")]
             chain.push(metering::Metering::new(
-                    &OPCODE_COSTS,
-                    options.unmetered_locals
-                ));
+                &OPCODE_COSTS,
+                options.unmetered_locals,
+            ));
         }
 
         chain.push(opcode_control::OpcodeControl::new(
-                options.max_memory_grow,
-                options.max_memory_grow_delta
-            ));
+            options.max_memory_grow,
+            options.max_memory_grow_delta,
+        ));
 
         // The RuntimeBreakpointHandler must be the last middleware in the chain (OpcodeTracer is
         // an exception since it does not alter the opcodes meaningfully.
@@ -323,10 +322,10 @@ pub unsafe fn get_compiler(chain_generator: impl Fn() -> MiddlewareChain) -> imp
     #[cfg(feature = "cranelift-backend")]
     use wasmer_clif_backend::CraneliftModuleCodeGenerator as MeteredMCG;
 
-    let compiler: StreamingCompiler<MeteredMCG, _, _, _, _> = StreamingCompiler::new(chain_generator);
+    let compiler: StreamingCompiler<MeteredMCG, _, _, _, _> =
+        StreamingCompiler::new(chain_generator);
     compiler
 }
-
 
 /// Returns the instance context. Learn more by looking at the
 /// `wasmer_instance_context_t` struct.
@@ -511,7 +510,8 @@ pub unsafe extern "C" fn wasmer_instance_call(
         }
     };
 
-    let last_opcode_location = wasmer_middleware_common::opcode_trace::get_opcodetracer_last_location(instance);
+    let last_opcode_location =
+        wasmer_middleware_common::opcode_trace::get_opcodetracer_last_location(instance);
     if last_opcode_location > 0 {
         let imported_functions = instance.module.info.name_table.to_vec();
         for i in 0..imported_functions.len() {
@@ -522,7 +522,10 @@ pub unsafe extern "C" fn wasmer_instance_call(
             println!("Export {:?}\t{}", v, k);
         }
 
-        println!("wasmer_instance_call OPCODE_LAST_LOCATION = {}", last_opcode_location);
+        println!(
+            "wasmer_instance_call OPCODE_LAST_LOCATION = {}",
+            last_opcode_location
+        );
     }
 
     result

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -27,6 +27,8 @@ use wasmer_middleware_common::opcode_control;
 use wasmer_middleware_common::opcode_trace;
 use wasmer_middleware_common::runtime_breakpoints;
 
+use wasmer_runtime_core::backing::{RESET_BACKING_GLOBALS, RESET_BACKING_MEMORIES};
+
 /// Opaque pointer to a `wasmer_runtime::Instance` value in Rust.
 ///
 /// A `wasmer_runtime::Instance` represents a WebAssembly instance. It
@@ -719,4 +721,11 @@ pub extern "C" fn wasmer_instance_destroy(instance: *mut wasmer_instance_t) {
     if !instance.is_null() {
         unsafe { Box::from_raw(instance as *mut Instance) };
     }
+}
+
+#[allow(clippy::cast_ptr_alignment)]
+#[no_mangle]
+pub unsafe extern "C" fn wasmer_instance_reset_options(reset_memories: bool, reset_globals: bool) {
+    RESET_BACKING_MEMORIES = reset_memories;
+    RESET_BACKING_GLOBALS = reset_globals;
 }

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -263,8 +263,9 @@ pub unsafe extern "C" fn wasmer_instantiate_reset(
         return wasmer_result_t::WASMER_ERROR;
     }
 
-    let instance = unsafe { &*(instance as *const Instance) };
+    let instance = &mut *(instance as *mut Instance);
     instance.reset();
+    wasmer_result_t::WASMER_OK
 }
 
 pub unsafe fn prepare_middleware_chain_generator(

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn wasmer_instantiate_with_options(
     wasmer_result_t::WASMER_OK
 }
 
-/// Resets an WebAssembly instance, cleaning memory annd globals
+/// Resets an WebAssembly instance, cleaning memory and globals
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_instantiate_reset(

--- a/lib/runtime-c-api/src/trampoline.rs
+++ b/lib/runtime-c-api/src/trampoline.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn wasmer_trampoline_buffer_builder_build(
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe extern "C" fn wasmer_trampoline_buffer_destroy(buffer: *mut wasmer_trampoline_buffer_t) {
     if !buffer.is_null() {
-        Box::from_raw(buffer as *mut TrampolineBuffer);
+        drop(Box::from_raw(buffer as *mut TrampolineBuffer));
     }
 }
 

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1092,7 +1092,10 @@ uint64_t wasmer_instance_get_runtime_breakpoint_value(wasmer_instance_t *instanc
  */
 bool wasmer_instance_is_function_imported(wasmer_instance_t *instance, const char *name);
 
-void wasmer_instance_reset_options(bool reset_memories, bool reset_globals);
+/**
+ * Reset an WebAssembly instance, cleaning memories and globals
+ */
+wasmer_result_t wasmer_instance_reset(wasmer_instance_t *instance);
 
 void wasmer_instance_set_points_limit(wasmer_instance_t *instance, uint64_t limit);
 
@@ -1149,11 +1152,6 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    uint32_t wasm_bytes_len,
                                    wasmer_import_t *imports,
                                    int imports_len);
-
-/**
- * Resets an WebAssembly instance, cleaning memory and globals
- */
-wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,
                                                 uint8_t *wasm_bytes,

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1148,6 +1148,8 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    wasmer_import_t *imports,
                                    int imports_len);
 
+wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t **instance);
+
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,
                                                 uint8_t *wasm_bytes,
                                                 uint32_t wasm_bytes_len,

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1148,6 +1148,9 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    wasmer_import_t *imports,
                                    int imports_len);
 
+/**
+ * todo: add documentation
+ */
 wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1149,7 +1149,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    int imports_len);
 
 /**
- * todo: add documentation
+ * TODO: add documentation
  */
 wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1149,7 +1149,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    int imports_len);
 
 /**
- * TODO: add documentation
+ * Resets an WebAssembly instance, cleaning memory annd globals
  */
 wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1148,7 +1148,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    wasmer_import_t *imports,
                                    int imports_len);
 
-wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t **instance);
+wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,
                                                 uint8_t *wasm_bytes,

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1092,6 +1092,8 @@ uint64_t wasmer_instance_get_runtime_breakpoint_value(wasmer_instance_t *instanc
  */
 bool wasmer_instance_is_function_imported(wasmer_instance_t *instance, const char *name);
 
+void wasmer_instance_reset_options(bool reset_memories, bool reset_globals);
+
 void wasmer_instance_set_points_limit(wasmer_instance_t *instance, uint64_t limit);
 
 void wasmer_instance_set_points_used(wasmer_instance_t *instance, uint64_t new_gas);

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1149,7 +1149,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    int imports_len);
 
 /**
- * Resets an WebAssembly instance, cleaning memory annd globals
+ * Resets an WebAssembly instance, cleaning memory and globals
  */
 wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -891,7 +891,8 @@ uint64_t wasmer_instance_get_runtime_breakpoint_value(wasmer_instance_t *instanc
 /// Verifies whether the specified function name is imported by the given instance.
 bool wasmer_instance_is_function_imported(wasmer_instance_t *instance, const char *name);
 
-void wasmer_instance_reset_options(bool reset_memories, bool reset_globals);
+/// Reset an WebAssembly instance, cleaning memories and globals
+wasmer_result_t wasmer_instance_reset(wasmer_instance_t *instance);
 
 void wasmer_instance_set_points_limit(wasmer_instance_t *instance, uint64_t limit);
 
@@ -946,9 +947,6 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    uint32_t wasm_bytes_len,
                                    wasmer_import_t *imports,
                                    int imports_len);
-
-/// Resets an WebAssembly instance, cleaning memory and globals
-wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,
                                                 uint8_t *wasm_bytes,

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -891,6 +891,8 @@ uint64_t wasmer_instance_get_runtime_breakpoint_value(wasmer_instance_t *instanc
 /// Verifies whether the specified function name is imported by the given instance.
 bool wasmer_instance_is_function_imported(wasmer_instance_t *instance, const char *name);
 
+void wasmer_instance_reset_options(bool reset_memories, bool reset_globals);
+
 void wasmer_instance_set_points_limit(wasmer_instance_t *instance, uint64_t limit);
 
 void wasmer_instance_set_points_used(wasmer_instance_t *instance, uint64_t new_gas);

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -945,7 +945,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    wasmer_import_t *imports,
                                    int imports_len);
 
-/// Resets an WebAssembly instance, cleaning memory annd globals
+/// Resets an WebAssembly instance, cleaning memory and globals
 wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -945,7 +945,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    wasmer_import_t *imports,
                                    int imports_len);
 
-wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t **instance);
+wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,
                                                 uint8_t *wasm_bytes,

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -945,6 +945,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    wasmer_import_t *imports,
                                    int imports_len);
 
+/// todo: add documentation
 wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -945,7 +945,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    wasmer_import_t *imports,
                                    int imports_len);
 
-/// TODO: add documentation
+/// Resets an WebAssembly instance, cleaning memory annd globals
 wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -945,6 +945,8 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    wasmer_import_t *imports,
                                    int imports_len);
 
+wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t **instance);
+
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,
                                                 uint8_t *wasm_bytes,
                                                 uint32_t wasm_bytes_len,

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -945,7 +945,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    wasmer_import_t *imports,
                                    int imports_len);
 
-/// todo: add documentation
+/// TODO: add documentation
 wasmer_result_t wasmer_instantiate_reset(wasmer_instance_t *instance);
 
 wasmer_result_t wasmer_instantiate_with_options(wasmer_instance_t **instance,

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -113,8 +113,8 @@ impl LocalBacking {
         module_info: &ModuleInfo,
         memories: &SliceMap<LocalMemoryIndex, Memory>,
     ) -> RuntimeResult<()> {
-        Self::shrink_memories(memories)?;
         Self::zero_memories(memories);
+        Self::shrink_memories(memories)?;
         Self::reinitialize_memories(module_info, memories)
     }
 

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -126,6 +126,23 @@ impl LocalBacking {
         module_info: &ModuleInfo,
         memories: &mut SliceMap<LocalMemoryIndex, Memory>,
     ) -> RuntimeResult<()> {
+        Self::zero_memories(memories);
+        Self::reinitialize_memories(module_info, memories)
+    }
+
+    fn zero_memories(memories: &mut SliceMap<LocalMemoryIndex, Memory>) {
+        for (_index, memory) in memories.iter_mut() {
+            let view = &memory.view::<u64>();
+            for cell in view.iter() {
+                cell.set(0);
+            }
+        }
+    }
+
+    fn reinitialize_memories(
+        module_info: &ModuleInfo,
+        memories: &mut SliceMap<LocalMemoryIndex, Memory>,
+    ) -> RuntimeResult<()> {
         for data_initializer in module_info.data_initializers.iter() {
             let DataInitializer {
                 memory_index,
@@ -161,11 +178,9 @@ impl LocalBacking {
                 }
             }
         }
-
         Ok(())
     }
 
-    #[allow(dead_code)]
     fn reset_globals(
         module_info: &ModuleInfo,
         globals: &mut SliceMap<LocalGlobalIndex, Global>,

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -103,7 +103,7 @@ impl LocalBacking {
         })
     }
 
-    /// Reset the `LocalBacking` (`Memories` and `Globals`) for an `Instance` using provided `ModuleInfo`
+    /// Resets the `LocalBacking` (`Memories` and `Globals`) for an `Instance` using the provided `ModuleInfo`
     pub(crate) fn reset(&mut self, module_info: &ModuleInfo) -> RuntimeResult<()> {
         Self::reset_memories(&module_info, &mut self.memories)?;
         Self::reset_globals(&module_info, &mut self.globals)?;

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -120,6 +120,7 @@ impl LocalBacking {
 
     fn shrink_memories(memories: &SliceMap<LocalMemoryIndex, Memory>) -> RuntimeResult<()> {
         for (_index, memory) in memories.iter() {
+            println!("[DEBUG] Memory: {:?}", memory);
             memory.shrink_to_minimum()?;
         }
         Ok(())

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -104,26 +104,27 @@ impl LocalBacking {
     }
 
     /// todo: add documentation
-    pub(crate) fn reset(&mut self) {
+    pub(crate) fn reset(&mut self, module_info: &ModuleInfo) {
         println!("Resetting ~ Local Backing:\n");
-        Self::reset_globals();
+        Self::reset_globals(&module_info, &mut self.globals);
     }
 
-    fn reset_globals() {
-        // todo: adapt code
-        // if globals.len() > 0 {
-        // let init_globals = &instance.module.info.globals;
-        // let init_stack_offset = init_globals.iter().next().unwrap().1;
-        // let init_value = match &init_stack_offset.init {
-        //     Initializer::Const(value) => value.clone(),
-        //     Initializer::GetGlobal(_) => {
-        //         println!("Cannot reset stack offset [init value not const]");
-        //         return;
-        //     }
-        // };
-
-        // let stack_offset = globals.iter_mut().next().unwrap().1;
-        // stack_offset.set(init_value);
+    fn reset_globals(
+        module_info: &ModuleInfo,
+        globals: &mut SliceMap<LocalGlobalIndex, Global>
+    ) {
+        // todo: adapt code to reset all globals not only the stack offset
+        let init_globals = &module_info.globals;
+        let init_stack_offset = init_globals.iter().next().unwrap().1;
+        let init_value = match &init_stack_offset.init {
+            Initializer::Const(value) => value.clone(),
+            Initializer::GetGlobal(_) => {
+                println!("Cannot reset stack offset [init value not const]");
+                return;
+            }
+        };
+        let stack_offset = globals.iter_mut().next().unwrap().1;
+        stack_offset.set(init_value);
         println!("	[x] globals");
     }
 

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -105,14 +105,11 @@ impl LocalBacking {
 
     /// todo: add documentation
     pub(crate) fn reset(&mut self, module_info: &ModuleInfo) {
-        println!("Resetting ~ Local Backing:\n");
+        println!("Resetting ~ Local Backing:");
         Self::reset_globals(&module_info, &mut self.globals);
     }
 
-    fn reset_globals(
-        module_info: &ModuleInfo,
-        globals: &mut SliceMap<LocalGlobalIndex, Global>
-    ) {
+    fn reset_globals(module_info: &ModuleInfo, globals: &mut SliceMap<LocalGlobalIndex, Global>) {
         // todo: adapt code to reset all globals not only the stack offset
         let init_globals = &module_info.globals;
         let init_stack_offset = init_globals.iter().next().unwrap().1;

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -10,9 +10,9 @@ use crate::{
     table::Table,
     typed_func::{always_trap, Func},
     types::{
-        ImportedFuncIndex, ImportedGlobalIndex, ImportedMemoryIndex, ImportedTableIndex,
-        Initializer, LocalFuncIndex, LocalGlobalIndex, LocalMemoryIndex, LocalOrImport,
-        LocalTableIndex, SigIndex, Value,
+        GlobalInit, ImportedFuncIndex, ImportedGlobalIndex, ImportedMemoryIndex,
+        ImportedTableIndex, Initializer, LocalFuncIndex, LocalGlobalIndex, LocalMemoryIndex,
+        LocalOrImport, LocalTableIndex, SigIndex, Value,
     },
     vm,
 };
@@ -159,14 +159,16 @@ impl LocalBacking {
         globals: &mut SliceMap<LocalGlobalIndex, Global>,
     ) -> RuntimeResult<()> {
         for (index, global_init) in module_info.globals.iter() {
-            let value = match &global_init.init {
+            let GlobalInit { desc, init } = global_init;
+
+            let value = match init {
                 Initializer::Const(value) => value.clone(),
                 Initializer::GetGlobal(_index) => {
                     return Err(RuntimeError(Box::new("Initializer is not supported")))
                 }
             };
 
-            if global_init.desc.mutable {
+            if desc.mutable {
                 match globals.get_mut(index) {
                     Some(global) => global.set(value),
                     None => return Err(RuntimeError(Box::new("Undefined global"))),

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -166,9 +166,11 @@ impl LocalBacking {
                 }
             };
 
-            match globals.get_mut(index) {
-                Some(global) => global.set(value),
-                None => return Err(RuntimeError(Box::new("Undefined global"))),
+            if global_init.desc.mutable {
+                match globals.get_mut(index) {
+                    Some(global) => global.set(value),
+                    None => return Err(RuntimeError(Box::new("Undefined global"))),
+                }
             }
         }
 

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -120,7 +120,6 @@ impl LocalBacking {
 
     fn shrink_memories(memories: &SliceMap<LocalMemoryIndex, Memory>) -> RuntimeResult<()> {
         for (_index, memory) in memories.iter() {
-            println!("[DEBUG] Memory: {:?}", memory);
             memory.shrink_to_minimum()?;
         }
         Ok(())

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -103,6 +103,30 @@ impl LocalBacking {
         })
     }
 
+    /// todo: add documentation
+    pub(crate) fn reset(&mut self) {
+        println!("Resetting ~ Local Backing:\n");
+        Self::reset_globals();
+    }
+
+    fn reset_globals() {
+        // todo: adapt code
+        // if globals.len() > 0 {
+        // let init_globals = &instance.module.info.globals;
+        // let init_stack_offset = init_globals.iter().next().unwrap().1;
+        // let init_value = match &init_stack_offset.init {
+        //     Initializer::Const(value) => value.clone(),
+        //     Initializer::GetGlobal(_) => {
+        //         println!("Cannot reset stack offset [init value not const]");
+        //         return;
+        //     }
+        // };
+
+        // let stack_offset = globals.iter_mut().next().unwrap().1;
+        // stack_offset.set(init_value);
+        println!("	[x] globals");
+    }
+
     fn generate_local_functions(module: &ModuleInner) -> BoxedMap<LocalFuncIndex, *const vm::Func> {
         (0..module.info.func_assoc.len() - module.info.imported_functions.len())
             .map(|index| {

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{CreationError, LinkError, LinkResult, RuntimeResult, RuntimeError},
+    error::{CreationError, LinkError, LinkResult, RuntimeError, RuntimeResult},
     export::{Context, Export},
     global::Global,
     import::ImportObject,
@@ -10,9 +10,9 @@ use crate::{
     table::Table,
     typed_func::{always_trap, Func},
     types::{
-        ImportedFuncIndex, ImportedGlobalIndex, ImportedMemoryIndex, ImportedTableIndex,
-        Initializer, LocalFuncIndex, LocalGlobalIndex, LocalMemoryIndex, LocalOrImport,
-        LocalTableIndex, SigIndex, Value, GlobalInit,
+        GlobalInit, ImportedFuncIndex, ImportedGlobalIndex, ImportedMemoryIndex,
+        ImportedTableIndex, Initializer, LocalFuncIndex, LocalGlobalIndex, LocalMemoryIndex,
+        LocalOrImport, LocalTableIndex, SigIndex, Value,
     },
     vm,
 };
@@ -104,10 +104,8 @@ impl LocalBacking {
     }
 
     /// todo: add documentation
-    pub(crate) fn reset(
-        &mut self,
-        module_info: &ModuleInfo
-    ) -> RuntimeResult<()> {
+    pub(crate) fn reset(&mut self, module_info: &ModuleInfo) -> RuntimeResult<()> {
+        // todo: remove debug prints
         println!("Resetting ~ Local Backing:");
         Self::reset_globals(&module_info, &mut self.globals)?;
         Ok(())
@@ -115,11 +113,12 @@ impl LocalBacking {
 
     fn reset_globals(
         module_info: &ModuleInfo,
-        globals: &mut SliceMap<LocalGlobalIndex, Global>
+        globals: &mut SliceMap<LocalGlobalIndex, Global>,
     ) -> RuntimeResult<()> {
+        // todo: remove debug prints
         let init_globals = &module_info.globals;
         for (index, init_global) in init_globals.iter() {
-            let GlobalInit {desc, init} = init_global;
+            let GlobalInit { desc, init } = init_global;
 
             let value = if let Initializer::Const(v) = init {
                 v.clone()
@@ -127,17 +126,17 @@ impl LocalBacking {
                 return Err(RuntimeError(Box::new("Can only reset const globals")));
             };
 
-            match globals.get(index) {
+            match globals.get_mut(index) {
                 Some(g) => {
-                    if desc.mutable == true && value != g.get() {
+                    if desc.mutable == false && value != g.get() {
                         return Err(RuntimeError(Box::new("Immutable global found changed")));
                     }
                     g.set(value);
-                },
-                None => return Err(RuntimeError(Box::new("Missing global value to reset")))
+                }
+                None => return Err(RuntimeError(Box::new("Missing global value to reset"))),
             };
         }
-
+        println!("  [x] globals");
         Ok(())
     }
 

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -106,8 +106,28 @@ impl LocalBacking {
     /// todo: add documentation
     pub(crate) fn reset(&mut self, module_info: &ModuleInfo) -> RuntimeResult<()> {
         // todo: remove debug prints
-        println!("Resetting ~ Local Backing:");
+        println!("Resetting Local Backing:");
+        Self::reset_memories(&module_info, &mut self.memories)?;
+        Self::reset_tables(&module_info, &mut self.tables)?;
         Self::reset_globals(&module_info, &mut self.globals)?;
+        Ok(())
+    }
+
+    fn reset_memories(
+        _module_info: &ModuleInfo,
+        _memories: &mut SliceMap<LocalMemoryIndex, Memory>,
+    ) -> RuntimeResult<()> {
+        // todo: remove debug prints
+        println!("  [x] memories");
+        Ok(())
+    }
+
+    fn reset_tables(
+        _module_info: &ModuleInfo,
+        _tables: &mut SliceMap<LocalTableIndex, Table>,
+    ) -> RuntimeResult<()> {
+        // todo: remove debug prints
+        println!("  [x] tables");
         Ok(())
     }
 
@@ -134,7 +154,7 @@ impl LocalBacking {
                     g.set(value);
                 }
                 None => return Err(RuntimeError(Box::new("Missing global value to reset"))),
-            };
+            }
         }
         println!("  [x] globals");
         Ok(())

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -110,12 +110,10 @@ impl LocalBacking {
     pub(crate) fn reset(&mut self, module_info: &ModuleInfo) -> RuntimeResult<()> {
         unsafe {
             if RESET_BACKING_MEMORIES {
-                println!("[WASMER] Resetting the memory");
                 Self::reset_memories(&module_info, &mut self.memories)?;
             }
 
             if RESET_BACKING_GLOBALS {
-                println!("[WASMER] Resetting the globals");
                 Self::reset_globals(&module_info, &mut self.globals)?;
             }
         }
@@ -126,8 +124,16 @@ impl LocalBacking {
         module_info: &ModuleInfo,
         memories: &mut SliceMap<LocalMemoryIndex, Memory>,
     ) -> RuntimeResult<()> {
+        Self::shrink_memories(memories)?;
         Self::zero_memories(memories);
         Self::reinitialize_memories(module_info, memories)
+    }
+
+    fn shrink_memories(memories: &mut SliceMap<LocalMemoryIndex, Memory>) -> RuntimeResult<()> {
+        for (_index, memory) in memories.iter_mut() {
+            memory.shrink_to_minimum()?;
+        }
+        Ok(())
     }
 
     fn zero_memories(memories: &mut SliceMap<LocalMemoryIndex, Memory>) {

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -23,6 +23,9 @@ pub const INTERNALS_SIZE: usize = 256;
 
 pub(crate) struct Internals(pub(crate) [u64; INTERNALS_SIZE]);
 
+pub static mut RESET_BACKING_MEMORIES: bool = true;
+pub static mut RESET_BACKING_GLOBALS: bool = true;
+
 impl Debug for Internals {
     fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(formatter, "Internals({:?})", &self.0[..])
@@ -105,9 +108,17 @@ impl LocalBacking {
 
     /// Resets the `LocalBacking` (`Memories` and `Globals`) for an `Instance` using the provided `ModuleInfo`
     pub(crate) fn reset(&mut self, module_info: &ModuleInfo) -> RuntimeResult<()> {
-        Self::reset_memories(&module_info, &mut self.memories)?;
-        Self::reset_globals(&module_info, &mut self.globals)?;
+        unsafe {
+            if RESET_BACKING_MEMORIES {
+                println!("[WASMER] Resetting the memory");
+                Self::reset_memories(&module_info, &mut self.memories)?;
+            }
 
+            if RESET_BACKING_GLOBALS {
+                println!("[WASMER] Resetting the globals");
+                Self::reset_globals(&module_info, &mut self.globals)?;
+            }
+        }
         Ok(())
     }
 
@@ -154,6 +165,7 @@ impl LocalBacking {
         Ok(())
     }
 
+    #[allow(dead_code)]
     fn reset_globals(
         module_info: &ModuleInfo,
         globals: &mut SliceMap<LocalGlobalIndex, Global>,

--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -25,6 +25,9 @@ pub type ResolveResult<T> = std::result::Result<T, ResolveError>;
 /// Result of an attempt to parse bytes into a WebAssembly module.
 /// Aliases the standard `Result` with `ParseError` as the default error type.
 pub type ParseResult<T> = std::result::Result<T, ParseError>;
+/// Result of an attempt to create something, like a `Memory` or `Table`.
+/// Aliases the standard `Result` with `CreationError` as the default error type.
+pub type CreationResult<T> = std::result::Result<T, CreationError>;
 
 /// This is returned when the chosen compiler is unable to
 /// successfully compile the provided WebAssembly module into
@@ -148,25 +151,54 @@ impl PartialEq for LinkError {
 impl std::fmt::Display for LinkError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            LinkError::ImportNotFound {namespace, name} => write!(f, "Import not found, namespace: {}, name: {}", namespace, name),
-            LinkError::IncorrectGlobalDescriptor {namespace, name,expected,found} => {
+            LinkError::ImportNotFound { namespace, name } => write!(
+                f,
+                "Import not found, namespace: {}, name: {}",
+                namespace, name
+            ),
+            LinkError::IncorrectGlobalDescriptor {
+                namespace,
+                name,
+                expected,
+                found,
+            } => {
                 write!(f, "Incorrect global descriptor, namespace: {}, name: {}, expected global descriptor: {:?}, found global descriptor: {:?}", namespace, name, expected, found)
-            },
-            LinkError::IncorrectImportSignature{namespace, name,expected,found} => {
+            }
+            LinkError::IncorrectImportSignature {
+                namespace,
+                name,
+                expected,
+                found,
+            } => {
                 write!(f, "Incorrect import signature, namespace: {}, name: {}, expected signature: {}, found signature: {}", namespace, name, expected, found)
             }
-            LinkError::IncorrectImportType{namespace, name,expected,found} => {
+            LinkError::IncorrectImportType {
+                namespace,
+                name,
+                expected,
+                found,
+            } => {
                 write!(f, "Incorrect import type, namespace: {}, name: {}, expected type: {}, found type: {}", namespace, name, expected, found)
             }
-            LinkError::IncorrectMemoryDescriptor{namespace, name,expected,found} => {
+            LinkError::IncorrectMemoryDescriptor {
+                namespace,
+                name,
+                expected,
+                found,
+            } => {
                 write!(f, "Incorrect memory descriptor, namespace: {}, name: {}, expected memory descriptor: {:?}, found memory descriptor: {:?}", namespace, name, expected, found)
-            },
-            LinkError::IncorrectTableDescriptor{namespace, name,expected,found} => {
+            }
+            LinkError::IncorrectTableDescriptor {
+                namespace,
+                name,
+                expected,
+                found,
+            } => {
                 write!(f, "Incorrect table descriptor, namespace: {}, name: {}, expected table descriptor: {:?}, found table descriptor: {:?}", namespace, name, expected, found)
-            },
+            }
             LinkError::Generic { message } => {
                 write!(f, "{}", message)
-            },
+            }
         }
     }
 }

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -3,7 +3,9 @@
 use crate::{
     backend::RunnableModule,
     backing::{ImportBacking, LocalBacking},
-    error::{CallError, CallResult, ResolveError, ResolveResult, Result, RuntimeError, RuntimeResult},
+    error::{
+        CallError, CallResult, ResolveError, ResolveResult, Result, RuntimeError, RuntimeResult,
+    },
     export::{Context, Export, ExportIter, FuncPointer},
     global::Global,
     import::{ImportObject, LikeNamespace},
@@ -144,7 +146,7 @@ impl Instance {
         Ok(instance)
     }
 
-    /// TODO: add documentation
+    /// Reset an `Instance`
     pub fn reset(&mut self) -> RuntimeResult<()> {
         self.inner.backing.reset(&self.module.info)?;
         Ok(())

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -146,7 +146,7 @@ impl Instance {
 
     /// todo: add documentation
     pub fn reset(&mut self) {
-        self.inner.backing.reset()
+        self.inner.backing.reset(&self.module.info)
     }
 
     /// Load an `Instance` using the given loader.

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -146,10 +146,9 @@ impl Instance {
         Ok(instance)
     }
 
-    /// Resets an `Instance`
+    /// Reset an `Instance`
     pub fn reset(&mut self) -> RuntimeResult<()> {
-        self.inner.backing.reset(&self.module.info)?;
-        Ok(())
+        self.inner.backing.reset(&self.module.info)
     }
 
     /// Load an `Instance` using the given loader.

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -52,6 +52,7 @@ impl Drop for InstanceInner {
 pub struct Instance {
     /// Reference to the module used to instantiate this instance.
     pub module: Arc<ModuleInner>,
+    module_info: ModuleInfo,
     inner: Pin<Box<InstanceInner>>,
     #[allow(dead_code)]
     import_object: ImportObject,
@@ -91,6 +92,7 @@ impl Instance {
 
         let instance = Instance {
             module,
+            module_info: module.info, // this is an Arc, is that ok?
             inner,
             import_object: imports.clone_ref(),
         };
@@ -142,6 +144,9 @@ impl Instance {
         }
 
         Ok(instance)
+    }
+
+    pub fn reset(&mut self) {
     }
 
     /// Load an `Instance` using the given loader.

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -3,7 +3,7 @@
 use crate::{
     backend::RunnableModule,
     backing::{ImportBacking, LocalBacking},
-    error::{CallError, CallResult, ResolveError, ResolveResult, Result, RuntimeError},
+    error::{CallError, CallResult, ResolveError, ResolveResult, Result, RuntimeError, RuntimeResult},
     export::{Context, Export, ExportIter, FuncPointer},
     global::Global,
     import::{ImportObject, LikeNamespace},
@@ -145,8 +145,9 @@ impl Instance {
     }
 
     /// todo: add documentation
-    pub fn reset(&mut self) {
-        self.inner.backing.reset(&self.module.info)
+    pub fn reset(&mut self) -> RuntimeResult<()> {
+        self.inner.backing.reset(&self.module.info)?;
+        Ok(())
     }
 
     /// Load an `Instance` using the given loader.

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -146,7 +146,7 @@ impl Instance {
         Ok(instance)
     }
 
-    /// Reset an `Instance`
+    /// Resets an `Instance`
     pub fn reset(&mut self) -> RuntimeResult<()> {
         self.inner.backing.reset(&self.module.info)?;
         Ok(())

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -52,7 +52,6 @@ impl Drop for InstanceInner {
 pub struct Instance {
     /// Reference to the module used to instantiate this instance.
     pub module: Arc<ModuleInner>,
-    module_info: ModuleInfo,
     inner: Pin<Box<InstanceInner>>,
     #[allow(dead_code)]
     import_object: ImportObject,
@@ -92,7 +91,6 @@ impl Instance {
 
         let instance = Instance {
             module,
-            module_info: module.info, // this is an Arc, is that ok?
             inner,
             import_object: imports.clone_ref(),
         };
@@ -146,7 +144,9 @@ impl Instance {
         Ok(instance)
     }
 
+    /// todo: add documentation
     pub fn reset(&mut self) {
+        self.inner.backing.reset()
     }
 
     /// Load an `Instance` using the given loader.

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -144,7 +144,7 @@ impl Instance {
         Ok(instance)
     }
 
-    /// todo: add documentation
+    /// TODO: add documentation
     pub fn reset(&mut self) -> RuntimeResult<()> {
         self.inner.backing.reset(&self.module.info)?;
         Ok(())

--- a/lib/runtime-core/src/lib.rs
+++ b/lib/runtime-core/src/lib.rs
@@ -37,7 +37,9 @@ extern crate lazy_static;
 mod macros;
 #[doc(hidden)]
 pub mod backend;
-mod backing;
+
+#[doc(hidden)]
+pub mod backing;
 
 pub mod cache;
 pub mod codegen;

--- a/lib/runtime-core/src/memory/dynamic.rs
+++ b/lib/runtime-core/src/memory/dynamic.rs
@@ -109,8 +109,17 @@ impl DynamicMemory {
 
     /// Shrink the memory to the minimum number of pages.
     pub fn shrink_to_minimum(&mut self, local: &mut vm::LocalMemory) {
-        let min_size = self.min.bytes().0;
-        _= self.memory.split_at(min_size);
+        if self.size() == self.min {
+            // do not shrink if we are already at the minimum
+            return;
+        }
+
+        let min_size = self.min.bytes().0 + DYNAMIC_GUARD_SIZE;
+        println!(
+            "Shrinking to min size: {} pages",
+            min_size / u32::pow(2, 16) as usize
+        );
+        self.memory.split_at(min_size);
 
         local.base = self.memory.as_ptr();
         local.bound = min_size;

--- a/lib/runtime-core/src/memory/dynamic.rs
+++ b/lib/runtime-core/src/memory/dynamic.rs
@@ -110,15 +110,11 @@ impl DynamicMemory {
     /// Shrink the memory to the minimum number of pages.
     pub fn shrink_to_minimum(&mut self, local: &mut vm::LocalMemory) {
         if self.size() == self.min {
-            // do not shrink if we are already at the minimum
             return;
         }
 
         let min_size = self.min.bytes().0 + DYNAMIC_GUARD_SIZE;
-        println!(
-            "Shrinking to min size: {} pages",
-            min_size / u32::pow(2, 16) as usize
-        );
+
         self.memory.split_at(min_size);
 
         local.base = self.memory.as_ptr();

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -98,7 +98,7 @@ impl Memory {
     fn validate_memory_pages_count(pages: Pages) -> CreationResult<()> {
         if pages > MAX_MEMORY_PAGES_COUNT {
             return Err(CreationError::InvalidDescriptor(format!(
-                "Number of memory pages used: {:?} is more than the alllowed number of pages: {:?}",
+                "Number of memory pages used: {:?} is more than the allowed number of pages: {:?}",
                 pages, MAX_MEMORY_PAGES_COUNT
             )));
         }
@@ -330,7 +330,7 @@ impl UnsharedMemory {
 
         match &mut *storage {
             UnsharedMemoryStorage::Dynamic(dynamic_memory) => {
-                dynamic_memory.shrink_to_minimum(&mut local)
+                dynamic_memory.shrink_to_minimum(&mut local);
             }
             UnsharedMemoryStorage::Static(_static_memory) => {
                 return Err(RuntimeError(Box::new("Cannot shrink static memory")));

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -27,7 +27,7 @@ pub mod ptr;
 mod static_;
 mod view;
 
-/// todo: add documentation
+/// TODO: add documentation
 pub const MAX_MEMORIES_COUNT: usize = 1;
 
 #[derive(Clone)]

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -30,7 +30,7 @@ mod view;
 /// Maximum `Memories` allowed
 pub const MAX_MEMORIES_COUNT: usize = 1;
 /// Maxium `Pages` allowed per `Memory`
-pub const MAX_MEMORY_PAGES_COUNT: Pages = Pages(10);
+pub const MAX_MEMORY_PAGES_COUNT: Pages = Pages(20);
 
 #[derive(Clone)]
 enum MemoryVariant {

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -30,7 +30,7 @@ mod view;
 /// Maximum `Memories` allowed
 pub const MAX_MEMORIES_COUNT: usize = 1;
 /// Maxium `Pages` allowed per `Memory`
-pub const MAX_MEMORY_PAGES_COUNT: usize = 10;
+pub const MAX_MEMORY_PAGES_COUNT: Pages = Pages(10);
 
 #[derive(Clone)]
 enum MemoryVariant {
@@ -96,11 +96,10 @@ impl Memory {
     }
 
     fn validate_memory_pages_count(pages: Pages) -> CreationResult<()> {
-        let count = pages.0 as usize;
-        if count > MAX_MEMORY_PAGES_COUNT {
+        if pages > MAX_MEMORY_PAGES_COUNT {
             return Err(CreationError::InvalidDescriptor(format!(
-                "Number of memory pages used: {} is more than the alllowed number of pages: {}",
-                count, MAX_MEMORY_PAGES_COUNT
+                "Number of memory pages used: {:?} is more than the alllowed number of pages: {:?}",
+                pages, MAX_MEMORY_PAGES_COUNT
             )));
         }
 

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -14,7 +14,7 @@ use std::{cell::Cell, fmt, mem, sync::Arc};
 
 use std::sync::Mutex as StdMutex;
 
-use rkyv::{Archive, Serialize as RkyvSerialize, Deserialize as RkyvDeserialize};
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
 pub use self::dynamic::DynamicMemory;
 pub use self::static_::StaticMemory;
@@ -26,6 +26,9 @@ mod dynamic;
 pub mod ptr;
 mod static_;
 mod view;
+
+/// todo: add documentation
+pub const MAX_MEMORIES_COUNT: usize = 1;
 
 #[derive(Clone)]
 enum MemoryVariant {
@@ -175,7 +178,19 @@ impl fmt::Debug for Memory {
 }
 
 /// A kind a memory.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash, Archive, RkyvSerialize, RkyvDeserialize)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Archive,
+    RkyvSerialize,
+    RkyvDeserialize,
+)]
 pub enum MemoryType {
     /// A dynamic memory.
     Dynamic,

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -67,14 +67,17 @@ impl Memory {
     /// }
     /// ```
     pub fn new(desc: MemoryDescriptor) -> CreationResult<Self> {
-        if let Some(max) = desc.maximum {
-            if max < desc.minimum {
-                return Err(CreationError::InvalidDescriptor(
-                    "Max number of memory pages is less than the minimum number of pages"
-                        .to_string(),
-                ));
+        match desc.maximum {
+            Some(max) => {
+                if max < desc.minimum {
+                    return Err(CreationError::InvalidDescriptor(
+                        "Max number of memory pages is less than the minimum number of pages"
+                            .to_string(),
+                    ));
+                }
+                Self::validate_memory_pages_count(max)?;
             }
-            Self::validate_memory_pages_count(max)?;
+            None => Self::validate_memory_pages_count(desc.minimum)?,
         }
 
         if desc.shared && desc.maximum.is_none() {
@@ -96,7 +99,7 @@ impl Memory {
         let count = pages.0 as usize;
         if count > MAX_MEMORY_PAGES_COUNT {
             return Err(CreationError::InvalidDescriptor(format!(
-                "Max number of memory pages: {} is more than the alllowed number of pages: {}",
+                "Number of memory pages used: {} is more than the alllowed number of pages: {}",
                 count, MAX_MEMORY_PAGES_COUNT
             )));
         }

--- a/lib/runtime-core/src/sys/unix/memory.rs
+++ b/lib/runtime-core/src/sys/unix/memory.rs
@@ -203,15 +203,6 @@ impl Memory {
             let second_ptr = unsafe { self.ptr.add(offset) };
             let second_size = self.size - offset;
 
-            println!("[MAIN] Memory: {:p}", self.ptr);
-            println!("  Total: {} bytes", self.size);
-            println!(
-                "Splitting at offset: {} [DYNAMIC_GUARD_SIZE(2^12 bytes) added]",
-                offset
-            );
-            println!("[UNMAP] Memory: {:p}", second_ptr);
-            println!("  Dropping: {} bytes", second_size);
-
             self.size = offset;
 
             let second = Memory {

--- a/lib/runtime-core/src/sys/unix/memory.rs
+++ b/lib/runtime-core/src/sys/unix/memory.rs
@@ -8,8 +8,6 @@ use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use std::ops::{Bound, RangeBounds};
 use std::{env, fs::File, os::unix::io::IntoRawFd, path::Path, ptr, slice, sync::Arc};
 
-static mut PANIC_COUNTER: i32 = 2;
-
 unsafe impl Send for Memory {}
 unsafe impl Sync for Memory {}
 
@@ -268,15 +266,6 @@ impl Memory {
 
 impl Drop for Memory {
     fn drop(&mut self) {
-        unsafe {
-            if PANIC_COUNTER == 0 {
-                env::set_var("RUST_BACKTRACE", "full");
-                panic!("PANIC_COUNTER is 0, this should happen!");
-            }
-            PANIC_COUNTER -= 1;
-        }
-        println!("Dropping memory");
-        println!("ptr: {:p}", self.ptr);
         if !self.ptr.is_null() {
             let success = unsafe { libc::munmap(self.ptr as _, self.size) };
             assert_eq!(success, 0, "failed to unmap memory: {}", errno::errno());

--- a/lib/runtime-core/src/sys/unix/memory.rs
+++ b/lib/runtime-core/src/sys/unix/memory.rs
@@ -6,7 +6,7 @@ use nix::libc;
 use page_size;
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use std::ops::{Bound, RangeBounds};
-use std::{env, fs::File, os::unix::io::IntoRawFd, path::Path, ptr, slice, sync::Arc};
+use std::{fs::File, os::unix::io::IntoRawFd, path::Path, ptr, slice, sync::Arc};
 
 unsafe impl Send for Memory {}
 unsafe impl Sync for Memory {}

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -378,7 +378,7 @@ impl<'a> DynamicFunc<'a> {
             fn drop(&mut self) {
                 unsafe {
                     TrampolineBufferBuilder::remove_global(self.ptr);
-                    Box::from_raw(self.ctx);
+                    drop(Box::from_raw(self.ctx));
                 }
             }
         }

--- a/lib/runtime-core/src/types.rs
+++ b/lib/runtime-core/src/types.rs
@@ -428,6 +428,7 @@ macro_rules! define_map_index {
         /// Typed Index
         #[derive(Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[repr(C)]
         pub struct $ty (u32);
         impl TypedIndex for $ty {
             #[doc(hidden)]

--- a/lib/runtime-core/src/units.rs
+++ b/lib/runtime-core/src/units.rs
@@ -18,6 +18,7 @@ pub const WASM_MIN_PAGES: usize = 256;
 
 /// Units of WebAssembly pages (as specified to be 65,536 bytes).
 #[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Archive, RkyvSerialize, RkyvDeserialize)]
+#[repr(C)]
 pub struct Pages(pub u32);
 
 impl Pages {

--- a/lib/singlepass-backend/src/emitter_x64.rs
+++ b/lib/singlepass-backend/src/emitter_x64.rs
@@ -456,7 +456,7 @@ macro_rules! binop_shift {
 
 macro_rules! jmp_op {
     ($ins:ident, $assembler:tt, $label:ident) => {
-        dynasm!($assembler ; $ins =>$label);
+        dynasm!($assembler ; $ins =>$label)
     }
 }
 
@@ -468,7 +468,7 @@ macro_rules! trap_op {
             ; trap:
             ; ud2
             ; after:
-        );
+        )
     }
 }
 


### PR DESCRIPTION
### Description:
Whenever we use a warm instance(for the same SC) we want to clean the memories and reset the changed globals from last execution.

`Memory` is first shrinked to min mem pages (drop extra mem pages created), then zeroed (cleaned) then we reset de data initializers (data)
`Globals` are changed back to [before execution value]

`pub unsafe extern "C" fn wasmer_instance_reset` can be used as entry point for review

### **_todo_**: 
- [x] bridge
- [x] reset globals
- [x] reset memories
- [x] constraints on memory
- [x] refactor

PS: _some changes are just warning fixes_

